### PR TITLE
Attempting some stack safety strategies

### DIFF
--- a/bench/Bench/Data/List.purs
+++ b/bench/Bench/Data/List.purs
@@ -3,18 +3,22 @@ module Bench.Data.List where
 import Prelude
 import Data.Foldable (maximum)
 import Data.Int (pow)
-import Data.List (List(..), take, range, foldr, length, nub)
+import Data.List (List(..), take, range, foldr, length, nub, nubBy, nubBySafe, nubByAdjacentReverse)
 import Data.Maybe (fromMaybe)
 import Data.Traversable (traverse_)
 import Effect (Effect)
 import Effect.Console (log)
-import Performance.Minibench (bench)
+import Performance.Minibench (bench, benchWith)
 
 benchList :: Effect Unit
 benchList = do
   --benchLists "map" $ map (_ + 1)
   --benchLists "foldr" $ foldr add 0
-  benchLists "nub" nub
+
+  --benchLists "nub" nub -- not stack safe
+  --benchLists "nubByAdjacentReverse" $ nubByAdjacentReverse eq -- safe
+  --benchLists "nubBySafe" $ nubBySafe compare -- safe
+  benchLists "nubBy" $ nubBy compare -- not stack safe
 
   where
 
@@ -30,4 +34,4 @@ benchList = do
   benchAList label func list = do
     log "---"
     log $ label <> ": list (" <> show (length list) <> " elems)"
-    bench \_ -> func list
+    benchWith 1 \_ -> func list

--- a/bench/Bench/Data/List.purs
+++ b/bench/Bench/Data/List.purs
@@ -3,7 +3,7 @@ module Bench.Data.List where
 import Prelude
 import Data.Foldable (maximum)
 import Data.Int (pow)
-import Data.List (List(..), take, range, foldr, length, nub, nubBy, nubBySafe, nubByAdjacentReverse)
+import Data.List (List(..), take, range, foldr, length, sortBy, addIndexReverse, mapReverse, nub, nubBy, nubBySafe, nubByAdjacentReverse)
 import Data.Maybe (fromMaybe)
 import Data.Traversable (traverse_)
 import Effect (Effect)
@@ -16,13 +16,16 @@ benchList = do
   --benchLists "foldr" $ foldr add 0
 
   --benchLists "nub" nub -- not stack safe
-  --benchLists "nubByAdjacentReverse" $ nubByAdjacentReverse eq -- safe
-  --benchLists "nubBySafe" $ nubBySafe compare -- safe
-  benchLists "nubBy" $ nubBy compare -- not stack safe
+  benchLists "nubByAdjacentReverse" $ nubByAdjacentReverse eq -- safe
+  benchLists "nubBySafe" $ nubBySafe compare -- safe
+  benchLists "addIndexReverse" addIndexReverse -- safe
+  benchLists "mapReverse" $ mapReverse $ add 1 -- safe
+  benchLists "sortBy" $ sortBy compare -- NOT SAFE!!!!
+  --benchLists "nubBy" $ nubBy compare -- not stack safe
 
   where
 
-  listSizes = Cons 0 $ map (pow 10) $ range 0 5
+  listSizes = Cons 0 $ map (pow 10) $ range 0 6
   nats = range 0 $ (fromMaybe 0 $ maximum listSizes) - 1
   lists = map (\n -> take n nats) listSizes
 

--- a/src/Data/List.purs
+++ b/src/Data/List.purs
@@ -74,6 +74,8 @@ module Data.List
   , partition
 
   , nubByAdjacentReverse
+  , addIndexReverse
+  , mapReverse
   , nubBySafe
 
   , nub


### PR DESCRIPTION
`nubBy`'s stack safety issue appears to be caused by `nubByAdjacentReverse`, but that function is stack safe on it's own.